### PR TITLE
address 2 build problems on java1.8 on Red Hat 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ description = 'This library provides support for the NAACCR XML format.'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-println "Starting build using JDK ${Runtime.version().feature()}"
-
 repositories {
     mavenCentral()
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -13,7 +13,7 @@ task createLauncherJar(type: Jar) {
                 'Built-Date': new Date(),
                 'Built-JDK': System.getProperty('java.version'),
                 'Main-Class': 'com.imsweb.naaccrxml.gui.Standalone',
-                'Class-Path': (configurations.runtimeClasspath.collect { it.getName() } + List.of("${project.name}-${version}.jar")).join(' '))
+                'Class-Path': (configurations.runtimeClasspath.collect { it.getName() } + ["${project.name}-${version}.jar"]).join(' '))
     }
 }
 


### PR DESCRIPTION
for reference:

```
$ java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM (build 25.212-b04, mixed mode)

$ cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.6 (Maipo)
```
